### PR TITLE
Make the logback appender exit cleanly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>sumo-logback-appender</groupId>
     <artifactId>sumo-logback-appender</artifactId>
-    <version>1.0.3-SNAPSHOT</version>
+    <version>1.0.3</version>
     <build>
         <plugins>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>sumo-logback-appender</groupId>
     <artifactId>sumo-logback-appender</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3-SNAPSHOT</version>
     <build>
         <plugins>
             <plugin>

--- a/src/main/java/com/sumologic/logback/BufferedSumoLogicAppender.java
+++ b/src/main/java/com/sumologic/logback/BufferedSumoLogicAppender.java
@@ -52,7 +52,7 @@ public class BufferedSumoLogicAppender extends AppenderBase<ILoggingEvent> {
     private int retryInterval = 10000;        // Once a request fails, how often until we retry.
 
     private long messagesPerRequest = 100;    // How many messages need to be in the queue before we flush
-    private long maxFlushInterval = 10000;    // Maximum interval between flushes (ms)
+    private long maxFlushInterval = 3000;    // Maximum interval between flushes (ms)
     private long flushingAccuracy = 250;      // How often the flushed thread looks into the message queue (ms)
     private String sourceName = "sumo-logback-appender"; // Name to stamp for querying with _sourceName
 
@@ -170,12 +170,19 @@ public class BufferedSumoLogicAppender extends AppenderBase<ILoggingEvent> {
 
     @Override
     public void stop() {
+        LogLog.debug("Trying to stop");
         super.stop();
-        sender.close();
-        sender = null;
 
-        flusher.stop();
-        flusher = null;
+        if (flusher != null) {
+            flusher.stop();
+            flusher = null;
+        }
+
+        if (sender != null) {
+            sender.close();
+            sender = null;
+        }
+
     }
 
     // Private bits.

--- a/src/main/java/com/sumologic/logback/aggregation/BufferFlushingTask.java
+++ b/src/main/java/com/sumologic/logback/aggregation/BufferFlushingTask.java
@@ -49,7 +49,7 @@ public abstract class BufferFlushingTask<In, Out> implements Runnable {
                (currentTime >= dateOfNextFlush);
     }
 
-    private void flushAndSend() {
+    public void flushAndSend() {
         List<In> messages = new ArrayList<In>(messageQueue.size());
         messageQueue.drainTo(messages);
 

--- a/src/main/java/com/sumologic/logback/aggregation/SumoBufferFlusher.java
+++ b/src/main/java/com/sumologic/logback/aggregation/SumoBufferFlusher.java
@@ -68,7 +68,6 @@ public class SumoBufferFlusher {
                 public Thread newThread(Runnable r) {
                     Thread thread = new Thread(r);
                     thread.setName("SumoBufferFlusherThread");
-                    thread.setDaemon(true);
                     return thread;
                 }
             });
@@ -77,7 +76,6 @@ public class SumoBufferFlusher {
         future =
             executor.
                 scheduleAtFixedRate(flushingTask, 0, flushingAccuracy, TimeUnit.MILLISECONDS);
-
     }
 
 
@@ -87,11 +85,10 @@ public class SumoBufferFlusher {
             future.cancel(false);
             future = null;
         }
+        flushingTask.flushAndSend();
 
         if (executor != null) {
             executor.shutdownNow();
         }
     }
-
-
 }


### PR DESCRIPTION
The logback appender was set as a daemon thread, which means the JVM
does give an eff if it has cleaned up correctly when it was shutting
down.  This causes the messages that were queued to get sent to just get
dropped.

This is problematic because the messages that are still in the queue are
usually the error messages from shutting down.

This makes the apps in charge of shutting down the thread then, using
the method described here:
http://logback.qos.ch/manual/configuration.html#stopContext

I was looking to see if this was something that should be normally
done...looking at the logback logstash appender under the TCP appenders
section, it suggests shutting down logback cleanly too to ensure all
messages are sent:
https://github.com/logstash/logstash-logback-encoder#tcp-appenders.
Perhaps not a clear precedence, but at least mentioned in another
context
